### PR TITLE
Target Python 3.12

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,7 +1,7 @@
 line-length = 120
 output-format = "grouped"
 show-fixes = true
-target-version = "py311"
+target-version = "py312"
 
 [format]
 docstring-code-format = true


### PR DESCRIPTION
#### Description
This PR simply updates `.ruff.toml` to target Python 3.12 instead of 3.11.

### Resolved Issues
* Closes #17